### PR TITLE
Rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# python specific
+env*
+.cache/
+*.pyc
+*.so
+*.pyd
+build/*
+dist/*
+MANIFEST
+__pycache__/
+*.egg-info/
+.coverage
+.python-version
+htmlcov
+
+# generic files to ignore
+*~
+*.lock
+*.DS_Store
+*.swp
+*.out
+
+.tox/
+deps/
+docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: trusty
+language: python
+sudo: true
+services:
+  - rabbitmq
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install:
+  - pip install -U setuptools
+  - pip install -U pip
+  - pip install -U wheel
+  - pip install -U tox
+script:
+  - export TOXENV=py`python -c 'import sys; print("".join(map(str, sys.version_info[:2])))'`
+  - echo "$TOXENV"
+
+  - tox
+cache:
+  directories:
+    - $HOME/.cache/pip
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) WikiBusiness Corporation. http://wikibusiness.org/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,67 @@
+aioelasticsearch
+================
+
+:info: aioelasticsearch-py wrapper for asyncio
+
+.. image:: https://img.shields.io/travis/wikibusiness/aioelasticsearch.svg
+    :target: https://travis-ci.org/wikibusiness/aioelasticsearch
+
+.. image:: https://img.shields.io/pypi/v/aioelasticsearch.svg
+    :target: https://pypi.python.org/pypi/aioelasticsearch
+
+Installation
+------------
+
+.. code-block:: shell
+
+    pip install aioelasticsearch
+
+Usage
+-----
+
+.. code-block:: python
+
+    import asyncio
+
+    from aioelasticsearch import Elasticsearch
+
+    async def go():
+        es = Elasticsearch()
+
+        print(await es.search())
+
+        await es.close()
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(go())
+    loop.close()
+
+Features
+--------
+
+Asynchronous `scroll <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html>`_
+
+.. code-block:: python
+
+    import asyncio
+
+    from aioelasticsearch import Elasticsearch
+    from aioelasticsearch.helpers import Scan
+
+    async def go():
+        async with Elasticsearch() as es:
+            async with Scan(
+                es,
+                index='index',
+                doc_type='doc_type',
+                query={},
+            ) as scan:
+                print(scan.total)
+
+                async for scroll in scan:
+                    for doc in scroll:
+                        print(doc['_source'])
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(go())
+    loop.close()

--- a/aioamqp_consumer/__init__.py
+++ b/aioamqp_consumer/__init__.py
@@ -1,3 +1,5 @@
 from .consumer import Consumer  # noqa isort:skip
 from .exceptions import Ack, DeadLetter, Reject  # noqa isort:skip
 from .producer import Producer  # noqa isort:skip
+
+__version__ = '0.1'

--- a/aioamqp_consumer/compat.py
+++ b/aioamqp_consumer/compat.py
@@ -1,16 +1,49 @@
 import asyncio
+import inspect
+import sys
+from functools import partial
 
-try:
-    from asyncio import ensure_future
-except ImportError:
-    ensure_future = getattr(asyncio, 'async')
+PY_344 = sys.version_info >= (3, 4, 4)
+PY_350 = sys.version_info >= (3, 5, 0)
+PY_352 = sys.version_info >= (3, 5, 2)
+
+
+def create_task(*, loop=None):
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
+    if PY_352:
+        return loop.create_task
+
+    if PY_344:
+        return partial(asyncio.ensure_future, loop=loop)
+
+    return partial(getattr(asyncio, 'async'), loop=loop)
 
 
 def create_future(*, loop=None):
     if loop is None:
         loop = asyncio.get_event_loop()
 
-    try:
+    if PY_352:
         return loop.create_future()
-    except AttributeError:
-        return asyncio.Future(loop=loop)
+
+    return asyncio.Future(loop=loop)
+
+
+def iscoroutinepartial(fn):
+    # http://bugs.python.org/issue23519
+
+    parent = fn
+
+    while fn is not None:
+        parent, fn = fn, getattr(parent, 'func', None)
+
+    return asyncio.iscoroutinefunction(parent)
+
+
+def iscoroutine(fn):
+    if PY_350:
+        return inspect.isawaitable(fn)
+
+    return iscoroutinepartial(fn)

--- a/aioamqp_consumer/consumer.py
+++ b/aioamqp_consumer/consumer.py
@@ -338,10 +338,7 @@ class Consumer(AMQPMixin):
             try:
                 yield from super()._connect(self.amqp_url, **self.amqp_kwargs)
 
-                yield from self._queue_declare(
-                    queue_name=self.queue_name,
-                    durable=True,
-                )
+                yield from self._queue_declare(queue_name=self.queue_name)
 
                 self._up.set()
 

--- a/aioamqp_consumer/mixins.py
+++ b/aioamqp_consumer/mixins.py
@@ -27,6 +27,9 @@ class AMQPMixin:
 
     @asyncio.coroutine
     def _connect(self, url, on_error=None, **kwargs):
+        if self._connected:
+            return
+
         assert not self._closed, 'Already closed'
         assert self._transport is None
         assert self._protocol is None
@@ -87,6 +90,12 @@ class AMQPMixin:
         _queue_declare = self._channel.queue_declare(**kwargs)
 
         return (yield from asyncio.shield(_queue_declare, loop=self.loop))
+
+    @asyncio.coroutine
+    def _queue_purge(self, *args, **kwargs):
+        _queue_purge = self._channel.queue_purge(*args, **kwargs)
+
+        return (yield from asyncio.shield(_queue_purge, loop=self.loop))
 
     @asyncio.coroutine
     def _basic_reject(self, *args, **kwargs):

--- a/aioamqp_consumer/mixins.py
+++ b/aioamqp_consumer/mixins.py
@@ -25,7 +25,8 @@ class AMQPMixin:
         if _code is not None or _message is not None:
             logger.exception(exc)
 
-    async def _connect(self, url, on_error=None, **kwargs):
+    @asyncio.coroutine
+    def _connect(self, url, on_error=None, **kwargs):
         assert not self._closed, 'Already closed'
         assert self._transport is None
         assert self._protocol is None
@@ -38,28 +39,29 @@ class AMQPMixin:
         kwargs['loop'] = self.loop
 
         try:
-            self._transport, self._protocol = await aioamqp.from_url(
+            self._transport, self._protocol = yield from aioamqp.from_url(
                 url,
-                **kwargs,
+                **kwargs
             )
         except OSError as exc:
             raise aioamqp.AioamqpException from exc
 
         _channel = self._protocol.channel()
 
-        self._channel = await asyncio.shield(_channel, loop=self.loop)
+        self._channel = yield from asyncio.shield(_channel, loop=self.loop)
 
         self._connected = True
 
         logger.debug('Connected amqp')
 
-    async def _disconnect(self):
+    @asyncio.coroutine
+    def _disconnect(self):
         if self._transport is not None and self._protocol is not None:
             if self._channel is not None:
                 try:
                     _close = self._channel.close()
 
-                    await asyncio.shield(_close, loop=self.loop)
+                    yield from asyncio.shield(_close, loop=self.loop)
 
                     logger.debug('Amqp channel is closed')
                 except aioamqp.AioamqpException:
@@ -68,7 +70,7 @@ class AMQPMixin:
             try:
                 _close = self._protocol.close()
 
-                await asyncio.shield(_close, loop=self.loop)
+                yield from asyncio.shield(_close, loop=self.loop)
 
                 self._transport.close()
 
@@ -80,32 +82,38 @@ class AMQPMixin:
         self._transport = self._protocol = self._channel = None
         self._connected = False
 
-    async def _queue_declare(self, **kwargs):
+    @asyncio.coroutine
+    def _queue_declare(self, **kwargs):
         _queue_declare = self._channel.queue_declare(**kwargs)
 
-        return await asyncio.shield(_queue_declare, loop=self.loop)
+        return (yield from asyncio.shield(_queue_declare, loop=self.loop))
 
-    async def _basic_reject(self, *args, **kwargs):
+    @asyncio.coroutine
+    def _basic_reject(self, *args, **kwargs):
         _basic_reject = self._channel.basic_reject(*args, **kwargs)
 
-        return await asyncio.shield(_basic_reject, loop=self.loop)
+        return (yield from asyncio.shield(_basic_reject, loop=self.loop))
 
-    async def _basic_client_ack(self, *args, **kwargs):
+    @asyncio.coroutine
+    def _basic_client_ack(self, *args, **kwargs):
         _ack = self._channel.basic_client_ack(*args, **kwargs)
 
-        return await asyncio.shield(_ack, loop=self.loop)
+        return (yield from asyncio.shield(_ack, loop=self.loop))
 
-    async def _basic_qos(self, **kwargs):
+    @asyncio.coroutine
+    def _basic_qos(self, **kwargs):
         _basic_qos = self._channel.basic_qos(**kwargs)
 
-        return await asyncio.shield(_basic_qos, loop=self.loop)
+        return (yield from asyncio.shield(_basic_qos, loop=self.loop))
 
-    async def _basic_consume(self, *args, **kwargs):
+    @asyncio.coroutine
+    def _basic_consume(self, *args, **kwargs):
         _basic_consume = self._channel.basic_consume(*args, **kwargs)
 
-        return await asyncio.shield(_basic_consume, loop=self.loop)
+        return (yield from asyncio.shield(_basic_consume, loop=self.loop))
 
-    async def _basic_publish(self, *args, **kwargs):
+    @asyncio.coroutine
+    def _basic_publish(self, *args, **kwargs):
         _basic_publish = self._channel.basic_publish(*args, **kwargs)
 
-        return await asyncio.shield(_basic_publish, loop=self.loop)
+        return (yield from asyncio.shield(_basic_publish, loop=self.loop))

--- a/aioamqp_consumer/producer.py
+++ b/aioamqp_consumer/producer.py
@@ -95,6 +95,18 @@ class Producer(AMQPMixin):
             raise
 
     @asyncio.coroutine
+    def queue_purge(self, queue_name, no_wait=False):
+        try:
+            assert not self._closed, 'Cannot publish while closed'
+
+            yield from self._connect()
+
+            yield from self._queue_purge(queue_name, no_wait=no_wait)
+        except:  # noqa
+            yield from self._disconnect()
+            raise
+
+    @asyncio.coroutine
     def _disconnect(self):
         self._known_queues = set()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts= -s --keep-duplicates --cache-clear --verbose --maxfail=1 --no-cov-on-fail --cov=aioamqp_consumer --cov-report=term --cov-report=html --fulltrace

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+aioamqp==0.10.0
+async-timeout==1.2.1
+coverage==4.4.1
+flake8==3.3.0
+isort==4.2.5
+mccabe==0.6.1
+py==1.4.34
+pycodestyle==2.3.1
+pyflakes==1.5.0
+pytest==3.1.1
+pytest-cov==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author='wikibusiness',
     author_email='osf@wikibusiness.org',
     url='https://github.com/wikibusiness/aioamqp_consumer',
-    description='Consumer/producer framework built on aioamqp',
+    description='Consumer/producer like library built over amqp (aioamqp)',
     long_description=read('README.rst'),
     install_requires=[
         'aioamqp==0.10.0',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,52 @@
+import io
+import os
+import re
+
+from setuptools import setup
+
+
+def get_version():
+    regex = r"__version__\s=\s\'(?P<version>[\d\.]+?)\'"
+
+    path = ('aioamqp_consumer', '__init__.py')
+
+    return re.search(regex, read(*path)).group('version')
+
+
+def read(*parts):
+    filename = os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts)
+
+    with io.open(filename, encoding='utf-8', mode='rt') as fp:
+        return fp.read()
+
+
+setup(
+    name='aioamqp_consumer',
+    version=get_version(),
+    author='wikibusiness',
+    author_email='osf@wikibusiness.org',
+    url='https://github.com/wikibusiness/aioamqp_consumer',
+    description='Consumer/producer framework built on aioamqp',
+    long_description=read('README.rst'),
+    install_requires=[
+        'aioamqp==0.10.0',
+        'async_timeout==1.2.1',
+    ],
+    packages=['aioamqp_consumer'],
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: POSIX',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    keywords=['aioamqp', 'amqp', 'asyncio', 'consumer', 'producer'],
+)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     long_description=read('README.rst'),
     install_requires=[
         'aioamqp==0.10.0',
-        'async_timeout==1.2.1',
     ],
     packages=['aioamqp_consumer'],
     include_package_data=True,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+import os  # noqa # isort:skip
+import logging  # noqa # isort:skip
+
+os.environ['PYTHONUNBUFFERED'] = '1'
+os.environ['PYTHONASYNCIODEBUG'] = '1'
+
+logging.basicConfig(level=logging.DEBUG)
+
+import asyncio  # noqa # isort:skip
+
+asyncio.set_event_loop(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ def loop(request):
 def producer(loop):
     producer = Producer(AMQP_URL, loop=loop)
 
+    loop.run_until_complete(producer.queue_purge(AMQP_QUEUE))
+
     try:
         yield producer
     finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,65 @@
+import asyncio
+
+import pytest
+from aioamqp_consumer import Producer
+
+AMQP_URL = 'amqp://guest:guest@127.0.0.1:5672//'
+AMQP_QUEUE = 'test'
+
+
+@pytest.fixture
+def loop(request):
+    with pytest.raises(RuntimeError):
+        asyncio.get_event_loop()
+
+    loop = asyncio.new_event_loop()
+
+    loop.set_debug(True)
+
+    request.addfinalizer(lambda: asyncio.set_event_loop(None))
+
+    try:
+        yield loop
+    finally:
+        loop.call_soon(loop.stop)
+        loop.run_forever()
+        loop.close()
+
+
+@pytest.fixture
+def producer(loop):
+    producer = Producer(AMQP_URL, loop=loop)
+
+    try:
+        yield producer
+    finally:
+        producer.close()
+        loop.run_until_complete(producer.wait_closed())
+
+
+@pytest.mark.tryfirst
+def pytest_pycollect_makeitem(collector, name, obj):
+    if collector.funcnamefilter(name):
+        item = pytest.Function(name, parent=collector)
+
+        if 'run_loop' in item.keywords:
+            return list(collector._genfunctions(name, obj))
+
+
+@pytest.mark.tryfirst
+def pytest_pyfunc_call(pyfuncitem):
+    if 'run_loop' in pyfuncitem.keywords:
+        funcargs = pyfuncitem.funcargs
+
+        loop = funcargs['loop']
+
+        testargs = {
+            arg: funcargs[arg]
+            for arg in pyfuncitem._fixtureinfo.argnames
+        }
+
+        assert asyncio.iscoroutinefunction(pyfuncitem.obj)
+
+        loop.run_until_complete(pyfuncitem.obj(**testargs))
+
+        return True

--- a/tests/test_aioamqp_consumer.py
+++ b/tests/test_aioamqp_consumer.py
@@ -17,11 +17,11 @@ def test_consumer(producer, loop):
     def task(payload, options, acc=None):
         acc.append(payload)
 
-    test_result = []
+    test_results = []
 
     consumer = Consumer(
         AMQP_URL,
-        partial(task, acc=test_result),
+        partial(task, acc=test_results),
         AMQP_QUEUE,
         loop=loop,
     )
@@ -30,3 +30,5 @@ def test_consumer(producer, loop):
 
     consumer.close()
     yield from consumer.wait_closed()
+
+    assert test_results == test_data

--- a/tests/test_aioamqp_consumer.py
+++ b/tests/test_aioamqp_consumer.py
@@ -1,0 +1,32 @@
+import asyncio
+from functools import partial
+
+import pytest
+from aioamqp_consumer import Consumer
+
+from tests.conftest import AMQP_QUEUE, AMQP_URL
+
+
+@pytest.mark.run_loop
+@asyncio.coroutine
+def test_consumer(producer, loop):
+    test_data = [b'test'] * 5
+    for data in test_data:
+        yield from producer.publish(data, AMQP_QUEUE, durable=True)
+
+    def task(payload, options, acc=None):
+        acc.append(payload)
+
+    test_result = []
+
+    consumer = Consumer(
+        AMQP_URL,
+        partial(task, acc=test_result),
+        AMQP_QUEUE,
+        loop=loop,
+    )
+
+    yield from consumer.join()
+
+    consumer.close()
+    yield from consumer.wait_closed()

--- a/tests/test_aioamqp_consumer.py
+++ b/tests/test_aioamqp_consumer.py
@@ -12,7 +12,7 @@ from tests.conftest import AMQP_QUEUE, AMQP_URL
 def test_consumer(producer, loop):
     test_data = [b'test'] * 5
     for data in test_data:
-        yield from producer.publish(data, AMQP_QUEUE, durable=True)
+        yield from producer.publish(data, AMQP_QUEUE)
 
     def task(payload, options, acc=None):
         acc.append(payload)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist =
+    py3{4,5,6}
+skip_missing_interpreters = True
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    flake8
+    isort
+commands =
+    flake8 --show-source aioelasticsearch
+    isort --check-only -rc aioelasticsearch --diff
+
+    flake8 --show-source setup.py
+    isort --check-only setup.py --diff
+
+    flake8 --show-source tests
+    isort --check-only -rc tests --diff
+
+    pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,7 @@ skip_missing_interpreters = True
 
 [testenv]
 deps =
-    pytest
-    pytest-cov
-    flake8
-    isort
+    -rrequirements.txt
 commands =
     flake8 --show-source aioelasticsearch
     isort --check-only -rc aioelasticsearch --diff


### PR DESCRIPTION
tox, travis, py34/35/36 compat, readme

- we need to decide what to do `durable=True` which is default for consumer, but not for producer
- i didn't add queue purge before test because since we don't have such functionality inside producer it will involve direct `aioamqp` usage, which is not desired IMO